### PR TITLE
Caching for getContactByKey

### DIFF
--- a/src/client/caching-client-wrapper.ts
+++ b/src/client/caching-client-wrapper.ts
@@ -14,13 +14,27 @@ class CachingClientWrapper {
   // -------------------------------------------------------------------
 
   public async getContactByEmail(email: string) {
-    const cachekey = `SFMC|Contact|${email}|${this.cachePrefix}`;
+    const cachekey = `SFMC|Contact|Email|${email}|${this.cachePrefix}`;
     const stored = await this.getCache(cachekey);
     if (stored) {
       return stored;
     }
 
     const result = await this.client.getContactByEmail(email);
+    if (result) {
+      await this.setCache(cachekey, result);
+    }
+    return result;
+  }
+
+  public async getContactByKey(contactKey: string) {
+    const cachekey = `SFMC|Contact|Key|${contactKey}|${this.cachePrefix}`;
+    const stored = await this.getCache(cachekey);
+    if (stored) {
+      return stored;
+    }
+
+    const result = await this.client.getContactByEmail(contactKey);
     if (result) {
       await this.setCache(cachekey, result);
     }


### PR DESCRIPTION
Add caching support for contact lookups
Changes:

- Added Redis caching for contact lookups by key
- Cache key format: SFMC|Contact|Key|{contactKey}|{cachePrefix}
- Cache duration set to 55 seconds
- Added cache miss handling with API fallback

This improves performance by reducing API calls for frequently accessed contacts during scenario execution.