### PR TITLE
expose records on pass using prefix

### DIFF
--- a/src/steps/contact/discover-contact.ts
+++ b/src/steps/contact/discover-contact.ts
@@ -80,7 +80,7 @@ export class DiscoverContact extends BaseStep implements StepInterface {
       }
     });
 
-    return this.keyValue('contact', 'Discovered Contact', obj);
+    return this.keyValue('exposeOnPass:contact', 'Discovered Contact', obj);
   }
 
   public createOrderedRecord(contact, stepOrder = 1): StepRecord {

--- a/src/steps/journey/discover-journey.ts
+++ b/src/steps/journey/discover-journey.ts
@@ -77,7 +77,7 @@ export class DiscoverJourney extends BaseStep implements StepInterface {
   }
 
   createRecord(journey: Record<string, any>) {
-    return this.keyValue('journey', 'Discovered Journey', journey);
+    return this.keyValue('exposeOnPass:journey', 'Discovered Journey', journey);
   }
 
   createOrderedRecord(journey: Record<string, any>, stepOrder = 1) {

--- a/src/steps/list/discover-list-members.ts
+++ b/src/steps/list/discover-list-members.ts
@@ -110,7 +110,7 @@ export class DiscoverListMembers extends BaseStep implements StepInterface {
       };
     });
 
-    return this.table('listMembers', `Members of List "${list.name}"`, headers, rows);
+    return this.table('exposeOnPass:listMembers', `Members of List "${list.name}"`, headers, rows);
   }
 }
 

--- a/src/steps/list/discover-lists.ts
+++ b/src/steps/list/discover-lists.ts
@@ -86,7 +86,7 @@ export class DiscoverLists extends BaseStep implements StepInterface {
       };
     });
 
-    return this.table('lists', 'Discovered Lists', headers, rows);
+    return this.table('exposeOnPass:lists', 'Discovered Lists', headers, rows);
   }
 }
 

--- a/test/steps/contact/discover-contact.ts
+++ b/test/steps/contact/discover-contact.ts
@@ -87,7 +87,7 @@ describe('DiscoverContact', () => {
     expect(records.length).to.equal(2);
     
     // Verify the first record (contact)
-    expect(records[0].getId()).to.equal('contact');
+    expect(records[0].getId()).to.equal('exposeOnPass:contact');
     
     // Safe access the record data
     const keyValue1 = records[0].getKeyValue();

--- a/test/steps/journey/discover-journey.ts
+++ b/test/steps/journey/discover-journey.ts
@@ -85,7 +85,7 @@ describe('DiscoverJourney', () => {
     expect(records.length).to.equal(2);
     
     // Verify the first record (journey)
-    expect(records[0].getId()).to.equal('journey');
+    expect(records[0].getId()).to.equal('exposeOnPass:journey');
     
     // Safe access the record data
     const keyValue1 = records[0].getKeyValue();


### PR DESCRIPTION
## Description
Enhanced the contact discovery functionality by exposing multiple contact records to the frontend interface using the `exposeOnPass` prefix. This change improves the visibility and accessibility of discovered contact data in the UI.

### Changes Made
- Modified the `createRecord` method to use `exposeOnPass:contact` as the record identifier
- Ensures discovered contact data is properly exposed and accessible through the frontend interface